### PR TITLE
Modify the tarballSources so that every version is found

### DIFF
--- a/cmd/godeb/main.go
+++ b/cmd/godeb/main.go
@@ -184,9 +184,8 @@ type tarballSource struct {
 }
 
 var tarballSources = []tarballSource{
-	{"https://code.google.com/p/go/downloads/list?can=1&q=linux", "//a/@href[contains(., 'go.googlecode.com')]"},
-	{"https://code.google.com/p/go/wiki/Downloads", "//a/@href[contains(., 'storage.googleapis.com')]"},
 	{"http://golang.org/dl/", "//a/@href[contains(., '/dl/')]"},
+	{"https://code.google.com/p/go/downloads/list?can=1&q=linux", "//a/@href[contains(., 'go.googlecode.com')]"},
 }
 
 func tarballs() ([]*Tarball, error) {


### PR DESCRIPTION
With this change, the 1.3rc's and anything new and old will be found,
previously by checking https://code.google.com/p/go/wiki/Downloads the
entire program failed with error: no downloads available at https://code.google.com/p/go/wiki/Downloads
