### PR TITLE
Update main.go

### DIFF
--- a/cmd/godeb/main.go
+++ b/cmd/godeb/main.go
@@ -185,7 +185,7 @@ type tarballSource struct {
 
 var tarballSources = []tarballSource{
 	{"https://code.google.com/p/go/downloads/list?can=1&q=linux", "//a/@href[contains(., 'go.googlecode.com')]"},
-	{"http://golang.org/dl/", "//a/@href[contains(., '/dl/')]"},
+	{"http://golang.org/dl/", "//a/@href[contains(., '/golang/')]"},
 }
 
 func tarballs() ([]*Tarball, error) {


### PR DESCRIPTION
The paths must have changed on http://golang.org/dl/, I was unable to run `godeb install` until I made this change locally and recompiled.
