### PR TITLE
Conflict, replace, and provide the golang-go package.

### DIFF
--- a/cmd/godeb/deb.go
+++ b/cmd/godeb/deb.go
@@ -50,7 +50,9 @@ Version: %s
 Architecture: %s
 Maintainer: Gustavo Niemeyer <niemeyer@canonical.com>
 Installed-Size: %d
-Conflicts: golang, golang-stable, golang-tip, golang-weekly
+Conflicts: golang-go, golang, golang-stable, golang-tip, golang-weekly
+Replaces: golang-go
+Provides: golang-go
 Section: devel
 Priority: extra
 Homepage: http://golang.org

--- a/cmd/godeb/main.go
+++ b/cmd/godeb/main.go
@@ -184,7 +184,7 @@ type tarballSource struct {
 }
 
 var tarballSources = []tarballSource{
-	{"http://golang.org/dl/", "//a/@href[contains(., 'storage.googleapis.com/golang/')]"},
+	{"https://golang.org/dl/", "//a/@href[contains(., 'redirector.gvt1.com/edgedl/go/')]"},
 }
 
 func tarballs() ([]*Tarball, error) {


### PR DESCRIPTION
In order to cleanly install over the golang-go package that is provided in Ubuntu, it is necessary to conflict, replace, and provide it in the generated go package.
