### PR TITLE
Connect to golang.org on https.

### DIFF
--- a/cmd/godeb/main.go
+++ b/cmd/godeb/main.go
@@ -184,7 +184,7 @@ type tarballSource struct {
 }
 
 var tarballSources = []tarballSource{
-	{"http://golang.org/dl/", "//a/@href[contains(., 'storage.googleapis.com/golang/')]"},
+	{"https://golang.org/dl/", "//a/@href[contains(., 'redirector.gvt1.com/edgedl/go/')]"},
 }
 
 func tarballs() ([]*Tarball, error) {


### PR DESCRIPTION
This avoids an unnecessary 302, which golang.org will always issue on connection to http://. Also prevents MITM shenanigans.