### PR TITLE
Change tarballSources

### DIFF
--- a/cmd/godeb/main.go
+++ b/cmd/godeb/main.go
@@ -184,7 +184,7 @@ type tarballSource struct {
 }
 
 var tarballSources = []tarballSource{
-	{"http://golang.org/dl/", "//a/@href[contains(., 'storage.googleapis.com/golang/')]"},
+	{"https://golang.org/dl/", "//a/@href[contains(., 'redirector.gvt1.com/edgedl/go/')]"},
 }
 
 func tarballs() ([]*Tarball, error) {

--- a/cmd/godeb/main.go
+++ b/cmd/godeb/main.go
@@ -72,7 +72,6 @@ func run() error {
 	default:
 		return fmt.Errorf("unknown command: %s", os.Args[1])
 	}
-	return nil
 }
 
 func listCommand() error {


### PR DESCRIPTION
http://golang.org/dl/          -> https://golang.org/dl/
storage.googleapis.com/golang/ -> redirector.gvt1.com/edgedl/go/
