### PR TITLE
The download URL now requires HTTPS, and refers to redirector.gvt1.com

### DIFF
--- a/cmd/godeb/main.go
+++ b/cmd/godeb/main.go
@@ -184,7 +184,7 @@ type tarballSource struct {
 }
 
 var tarballSources = []tarballSource{
-	{"http://golang.org/dl/", "//a/@href[contains(., 'storage.googleapis.com/golang/')]"},
+	{"https://golang.org/dl/", "//a/@href[contains(., 'redirector.gvt1.com/edgedl/go/')]"},
 }
 
 func tarballs() ([]*Tarball, error) {


### PR DESCRIPTION
It appears that the download links have changed.

The symptom is:
`error: no downloads available at http://golang.org/dl/`