### PR TITLE
Close #35 - reverse sort order

### DIFF
--- a/cmd/godeb/main.go
+++ b/cmd/godeb/main.go
@@ -214,7 +214,7 @@ func tarballs() ([]*Tarball, error) {
 	if err != nil {
 		return nil, err
 	}
-	sort.Sort(tarballSlice(tbs))
+	sort.Sort(sort.Reverse(tarballSlice(tbs)))
 	return tbs, nil
 }
 


### PR DESCRIPTION
Makes  ```godeb list``` shows bigger version at end of output