### PR TITLE
Warn instead of fail on invaild paths in tarball

### DIFF
--- a/cmd/godeb/deb.go
+++ b/cmd/godeb/deb.go
@@ -234,7 +234,8 @@ func translateTarball(now time.Time, tarball io.Reader) (dataTarGz, md5sums []by
 			}
 		}
 		if !strings.HasPrefix(h.Name, "go/") {
-			return nil, nil, 0, fmt.Errorf("upstream tarball has file in unexpected path: %s", h.Name)
+			fmt.Fprintln(os.Stderr, "warning: upstream tarball has file in unexpected path", h.Name)
+			continue
 		}
 		const prefix = "./usr/local/"
 		h.Name = prefix + h.Name


### PR DESCRIPTION
The build of Go 1.11.5 has some harmless build artifacts in the tarball;
emit a warning while iterating over those, rather than failing
completely.

See
https://groups.google.com/d/msg/golang-announce/mVeX35iXuSw/HxYXaBnYEAAJ