### PR TITLE
ignore unneeded build artifacts from go 1.11.5 release tarballs

### DIFF
--- a/cmd/godeb/deb.go
+++ b/cmd/godeb/deb.go
@@ -233,6 +233,10 @@ func translateTarball(now time.Time, tarball io.Reader) (dataTarGz, md5sums []by
 				return nil, nil, 0, fmt.Errorf("cannot write header of %s to data.tar.gz: %v", h.Name, err)
 			}
 		}
+		// ignoring unneeded build artifacts from go 1.11.5 release tarballs
+		if strings.HasPrefix(h.Name, "gocache/") || strings.HasPrefix(h.Name, "tmp/") {
+			continue
+		}
 		if !strings.HasPrefix(h.Name, "go/") {
 			return nil, nil, 0, fmt.Errorf("upstream tarball has file in unexpected path: %s", h.Name)
 		}


### PR DESCRIPTION
Make it possible to build debian packages from go1.11.5 release tarballs.

To not create warnings which could be overseen in automated CI pipelines, i created a patch to explicitely ignore the superfluous artifacts included in go1.11.5 release tarballs instead of just downgrading all errors from unknown content to warnings.

Reference: https://groups.google.com/d/msg/golang-announce/mVeX35iXuSw/HxYXaBnYEAAJ