### PR TITLE
Select tarball version from end of slice

### DIFF
--- a/cmd/godeb/main.go
+++ b/cmd/godeb/main.go
@@ -107,8 +107,8 @@ func actionCommand(version string, install bool) error {
 	}
 	var url string
 	if version == "" {
-		version = tbs[0].Version
-		url = tbs[0].URL
+		version = tbs[len(tbs) - 1].Version
+		url = tbs[len(tbs) - 1].URL
 	} else {
 		for _, tb := range tbs {
 			if version == tb.Version {


### PR DESCRIPTION
Currently a default "godeb install" installs the lowest available version as it is at the beginning of the slice.
This change selects the latest version, from the end of the slice.