### PR TITLE
Upgrade XPATH library to v2 (#44)

### DIFF
--- a/cmd/godeb/main.go
+++ b/cmd/godeb/main.go
@@ -13,7 +13,7 @@ import (
 	"bytes"
 	"fmt"
 	"go/build"
-	"gopkg.in/xmlpath.v1"
+	"gopkg.in/xmlpath.v2"
 	"io/ioutil"
 	"net/http"
 	"os"


### PR DESCRIPTION
Upgrade from gopkg.in/xmlpath.v1 to v2 for more forgiving XML parser, robust to badly formatted HTML