### PR TITLE
Fix bug on install without arguments and make it work on raspberry pi (raspbian)

### DIFF
--- a/cmd/godeb/deb.go
+++ b/cmd/godeb/deb.go
@@ -68,6 +68,13 @@ Description: Go language compiler and tools (gc)
 `
 
 func debArch() string {
+	cmd := exec.Command("dpkg", "--print-architecture")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return strings.TrimSpace(string(output))
+	}
+
+	//if unable to get the dpkg arch using dpkg command, fallback to GOARCH
 	arch := build.Default.GOARCH
 	if arch == "386" {
 		return "i386"

--- a/cmd/godeb/main.go
+++ b/cmd/godeb/main.go
@@ -30,7 +30,17 @@ Available commands:
     remove
 `
 
+var (
+	GOARCH = build.Default.GOARCH
+	GOOS = build.Default.GOOS
+)
+
 func main() {
+	if GOARCH == "arm" {
+		GOARCH = "armv6l"
+	}
+
+
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
@@ -200,7 +210,7 @@ func tarballs() ([]*Tarball, error) {
 	var tbs []*Tarball
 	for _, v := range versions {
 		for _, f := range v.Files {
-			if f.Os == build.Default.GOOS && f.Arch == build.Default.GOARCH {
+			if f.Os == GOOS && f.Arch == GOARCH {
 				t := Tarball{
 					Version: strings.TrimPrefix(f.Version, "go"),
 					URL:     downloadBaseURL + f.Filename}

--- a/cmd/godeb/main.go
+++ b/cmd/godeb/main.go
@@ -114,8 +114,8 @@ func actionCommand(version string, install bool) error {
 	}
 	var url string
 	if version == "" {
-		version = tbs[0].Version
-		url = tbs[0].URL
+		version = tbs[len(tbs)-1].Version
+		url = tbs[len(tbs)-1].URL
 	} else {
 		for _, tb := range tbs {
 			if version == tb.Version {


### PR DESCRIPTION
- Fix on install without arguments. Until now it was selecting the oldest version, after the fix will select the newest one. I thing the bug appeared when the list was reversed.
- Set package arch using the dpkg command and fallback to GOARCH if unable to get it
- Select arch armv6l when GOARCH is arm
